### PR TITLE
chore: group routine Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      routine-npm-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +22,7 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Group weekly npm minor and patch updates into one purpose-sized pull request.
- Group weekly GitHub Actions updates into one purpose-sized pull request.
- Keep npm major updates separate for explicit compatibility review.
- This reduces dependency-maintenance churn without changing required CI or security gates.

## Checklist
- [x] tests added/updated (N/A: configuration-only change; GitHub validates the Dependabot file)
- [x] security impact reviewed
- [x] docs updated (N/A: repository maintenance policy is expressed by the configuration)
- [x] `pnpm check` passes locally (N/A: no product source or lockfile changed)

## Validation
- Commands run: parsed and reviewed `.github/dependabot.yml`; current-head GitHub CI and Dependabot configuration validation.
- Key outputs/results: GitHub's `.github/dependabot.yml` validation check passed on commit `09132a23c8d470823788b950507fdda736dea436`.

## Related
- Issue/Thread/PR: dependency backlog cleanup across #14, #17-#26, #36, #39, #40, #42, and #45.
- Follow-up work (if any): observe the next weekly Dependabot run and adjust grouping only if GitHub emits invalid or overly broad updates.